### PR TITLE
Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,20 @@ Expects either a vanilla JS array or an immutableJS array, consisting of objects
 
 The preferred (fastest) option is to give unix timestamps in milliseconds for `start_time` and `end_time`. Objects that convert to them (java Date or moment()) will also work, but will be a lot slower.
 
+
+### ranges
+Expects either a vanilla JS array or an immutableJS array, consisting of objects with the following attributes:
+```
+{
+  id: 1,
+  start_time: 1457902922261,
+  end_time: 1457902922261 + 86400000,
+  className: 'weekend',
+}
+```
+
 ### keys
-An array specifying keys in the `items` and `groups` objects. Defaults to
+An array specifying keys in the `items`, `groups` and `ranges` objects. Defaults to
 ```
 {
   groupIdKey: 'id',
@@ -109,6 +121,9 @@ An array specifying keys in the `items` and `groups` objects. Defaults to
   itemGroupKey: 'group',
   itemTimeStartKey: 'start_time',
   itemTimeEndKey: 'end_time'
+  rangeIdKey: 'id',
+  rangeTimeStartKey: 'start_time',
+  rangeTimeEndKey: 'end_time'
 }
 ```
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
       },
 
       selected: null,
-      ranges: ranges,
+      ranges: [],
 
       onCanvasClick: function(event) {
         console.log("Canvas clicked");

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -896,7 +896,7 @@ export default class ReactCalendarTimeline extends Component {
               {this.verticalLines(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, timeSteps, height, headerHeight)}
               {this.horizontalLines(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, groupHeights, headerHeight)}
               {this.todayLine(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, height, headerHeight)}
-              {this.ranges(canvasTimeStart, canvasTimeEnd, canvasWidth, height, headerHeight)}
+              {this.props.ranges && this.ranges(canvasTimeStart, canvasTimeEnd, canvasWidth, height, headerHeight)}
               {this.infoLabel()}
               {this.header(
                 canvasTimeStart,

--- a/src/lib/ranges/Range.js
+++ b/src/lib/ranges/Range.js
@@ -17,7 +17,7 @@ export default class Range extends Component {
 
   left (canvasTimeStart, rangeStart, ratio) {
     if (rangeStart < canvasTimeStart) {
-     return 0
+      return 0;
     }
 
     if (rangeStart > canvasTimeStart) {


### PR DESCRIPTION


      
# missing configuration keys 
Add configuration keys for the range attributes.

```
rangeIdKey → done
rangeTimeStartKey → missing
rangeTimeEndKey → missing
```


# consistent naming 
naming for range objects like items
```
is:
      {
        id: ..,
        className: ..,
        start: ...,
        end: ...
      }

should:
      {
        id: ..,
        className: ..,
        start_time: ...,
        end_time: ...
      }
```

# Ranges component
no `defaultProps` needed if `propTypes`are `isRequired`

# Range component
* Set `propTypes` as static of class
* See comment in `Item` for `propTypes`
* Remove the first `if` in `render()` since it's already `isRequired` 

